### PR TITLE
Adding API endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'http://rubygems.org'
 
 gemspec
 
+gem 'puma', '~> 2.15'
+
 group :development do
   gem 'dotenv'
   gem 'pry-byebug'
@@ -12,4 +14,5 @@ end
 group :test do
   gem 'rspec'
   gem 'sqlite3'
+  gem 'rack-test'
 end

--- a/config.ru
+++ b/config.ru
@@ -1,0 +1,14 @@
+$:.unshift(File.dirname(__FILE__))
+$:.unshift(File.join(File.dirname(__FILE__), 'lib'))
+
+require 'txdb'
+
+map '/hooks' do
+  use Txdb::Hooks
+  run Sinatra::Base
+end
+
+map '/triggers' do
+  use Txdb::Triggers
+  run Sinatra::Base
+end

--- a/lib/txdb.rb
+++ b/lib/txdb.rb
@@ -10,6 +10,7 @@ module Txdb
   autoload :ResponseHelpers,  'txdb/response_helpers'
   autoload :Table,            'txdb/table'
   autoload :TransifexProject, 'txdb/transifex_project'
+  autoload :Triggers,         'txdb/app'
   autoload :TxResource,       'txdb/tx_resource'
   autoload :Uploader,         'txdb/uploader'
 

--- a/lib/txdb.rb
+++ b/lib/txdb.rb
@@ -4,6 +4,8 @@ module Txdb
   autoload :ConnectionString, 'txdb/connection_string'
   autoload :Database,         'txdb/database'
   autoload :Downloader,       'txdb/downloader'
+  autoload :Response,         'txdb/response'
+  autoload :ResponseHelpers,  'txdb/response_helpers'
   autoload :Table,            'txdb/table'
   autoload :TransifexProject, 'txdb/transifex_project'
   autoload :TxResource,       'txdb/tx_resource'

--- a/lib/txdb.rb
+++ b/lib/txdb.rb
@@ -4,6 +4,8 @@ module Txdb
   autoload :ConnectionString, 'txdb/connection_string'
   autoload :Database,         'txdb/database'
   autoload :Downloader,       'txdb/downloader'
+  autoload :Handlers,         'txdb/handlers'
+  autoload :Hooks,            'txdb/app'
   autoload :Response,         'txdb/response'
   autoload :ResponseHelpers,  'txdb/response_helpers'
   autoload :Table,            'txdb/table'

--- a/lib/txdb/app.rb
+++ b/lib/txdb/app.rb
@@ -1,0 +1,36 @@
+require 'sinatra'
+require 'sinatra/json'
+
+module Txdb
+  module RespondWith
+    def respond_with(resp)
+      env['txdb.response'] = resp
+      status resp.status
+      json resp.body
+    end
+  end
+
+  class Hooks < Sinatra::Base
+    include Txdb::Handlers
+
+    helpers RespondWith
+
+    post '/transifex' do
+      respond_with(HookHandler.handle_request(request))
+    end
+  end
+
+  class Triggers < Sinatra::Base
+    include Txdb::Handlers::Triggers
+
+    helpers RespondWith
+
+    patch '/push' do
+      respond_with(PushHandler.handle_request(request))
+    end
+
+    patch '/pull' do
+      respond_with(PullHandler.handle_request(request))
+    end
+  end
+end

--- a/lib/txdb/config.rb
+++ b/lib/txdb/config.rb
@@ -9,6 +9,11 @@ module Txdb
         end
       end
 
+      def each_table(&block)
+        return to_enum(__method__) unless block_given?
+        databases.each { |database| database.tables.each(&block) }
+      end
+
       private
 
       def raw_config

--- a/lib/txdb/downloader.rb
+++ b/lib/txdb/downloader.rb
@@ -18,12 +18,12 @@ module Txdb
       end
     end
 
-    private
-
     def download_table(table, locale)
       content = transifex_api.download(table.resource, locale)
       table.write_content(content, locale)
     end
+
+    private
 
     def transifex_api
       database.transifex_api

--- a/lib/txdb/handlers.rb
+++ b/lib/txdb/handlers.rb
@@ -1,0 +1,6 @@
+module Txdb
+  module Handlers
+    autoload :HookHandler, 'txdb/handlers/hook_handler'
+    autoload :Triggers,    'txdb/handlers/triggers'
+  end
+end

--- a/lib/txdb/handlers/hook_handler.rb
+++ b/lib/txdb/handlers/hook_handler.rb
@@ -5,25 +5,24 @@ module Txdb
   module Handlers
     class HookHandler
       class << self
-        def handle_request(request, project)
-          new(request, project).handle
+        def handle_request(request)
+          new(request).handle
         end
       end
 
       include ResponseHelpers
 
-      attr_reader :request, :project
+      attr_reader :request
 
-      def initialize(request, project)
+      def initialize(request)
         @request = request
-        @project = project
       end
 
       def handle
         locale = payload['language']
 
         tables.each do |table|
-          content = project.api.download(table.resource, locale)
+          content = table.database.transifex_api.download(table.resource, locale)
           table.write_content(content, locale)
         end
 

--- a/lib/txdb/handlers/hook_handler.rb
+++ b/lib/txdb/handlers/hook_handler.rb
@@ -19,8 +19,6 @@ module Txdb
       end
 
       def handle
-        locale = payload['language']
-
         tables.each do |table|
           content = table.database.transifex_api.download(table.resource, locale)
           table.write_content(content, locale)
@@ -32,6 +30,10 @@ module Txdb
       end
 
       private
+
+      def locale
+        payload['language']
+      end
 
       def tables
         @tables ||= Txdb::Config.each_table.select do |table|

--- a/lib/txdb/handlers/hook_handler.rb
+++ b/lib/txdb/handlers/hook_handler.rb
@@ -1,0 +1,58 @@
+require 'txgh'
+require 'uri'
+
+module Txdb
+  module Handlers
+    class HookHandler
+      class << self
+        def handle_request(request, project)
+          new(request, project).handle
+        end
+      end
+
+      include ResponseHelpers
+
+      attr_reader :request, :project
+
+      def initialize(request, project)
+        @request = request
+        @project = project
+      end
+
+      def handle
+        locale = payload['language']
+
+        tables.each do |table|
+          content = project.api.download(table.resource, locale)
+          table.write_content(content, locale)
+        end
+
+        respond_with(200, {})
+      rescue => e
+        respond_with_error(500, "Internal server error: #{e.message}", e)
+      end
+
+      private
+
+      def tables
+        @tables ||= Txdb::Config.each_table.select do |table|
+          table.resource.resource_slug == payload['resource'] &&
+            authentic_request?(table.database.transifex_project)
+        end
+      end
+
+      def authentic_request?(project)
+        Txgh::TransifexRequestAuth.authentic_request?(
+          request, project.webhook_secret
+        )
+      end
+
+      def payload
+        @payload ||= begin
+          request.body.rewind
+          Hash[URI.decode_www_form(request.body.read)]
+        end
+      end
+    end
+  end
+end

--- a/lib/txdb/handlers/triggers.rb
+++ b/lib/txdb/handlers/triggers.rb
@@ -1,0 +1,9 @@
+module Txdb
+  module Handlers
+    module Triggers
+      autoload :Handler,     'txdb/handlers/triggers/handler'
+      autoload :PullHandler, 'txdb/handlers/triggers/pull_handler'
+      autoload :PushHandler, 'txdb/handlers/triggers/push_handler'
+    end
+  end
+end

--- a/lib/txdb/handlers/triggers/handler.rb
+++ b/lib/txdb/handlers/triggers/handler.rb
@@ -2,11 +2,15 @@ module Txdb
   module Handlers
     module Triggers
       class Handler
+        include ResponseHelpers
+
         class << self
           def handle_request(request)
             new(request).handle
           end
         end
+
+        attr_reader :request
 
         def initialize(request)
           @request = request

--- a/lib/txdb/handlers/triggers/handler.rb
+++ b/lib/txdb/handlers/triggers/handler.rb
@@ -1,0 +1,40 @@
+module Txdb
+  module Handlers
+    module Triggers
+      class Handler
+        class << self
+          def handle_request(request)
+            new(request).handle
+          end
+        end
+
+        def initialize(request)
+          @request = request
+        end
+
+        private
+
+        def databases
+          @databases ||= if database_name = request.params['database']
+            Txdb::Config.databases.select do |database|
+              database.database == database_name
+            end
+          else
+            Txdb::Config.databases
+          end
+        end
+
+        def tables
+          @tables ||= each_table_in(databases).select do |table|
+            table.name == request.params['table']
+          end
+        end
+
+        def each_table_in(databases, &block)
+          return to_enum(__method__, databases) unless block_given?
+          databases.each { |database| database.tables.each(&block) }
+        end
+      end
+    end
+  end
+end

--- a/lib/txdb/handlers/triggers/handler.rb
+++ b/lib/txdb/handlers/triggers/handler.rb
@@ -18,6 +18,12 @@ module Txdb
 
         private
 
+        def handle_safely
+          yield
+        rescue => e
+          respond_with_error(500, "Internal server error: #{e.message}", e)
+        end
+
         def databases
           @databases ||= if database_name = request.params['database']
             Txdb::Config.databases.select do |database|

--- a/lib/txdb/handlers/triggers/pull_handler.rb
+++ b/lib/txdb/handlers/triggers/pull_handler.rb
@@ -4,15 +4,15 @@ module Txdb
 
       class PullHandler < Handler
         def handle
-          tables.each do |table|
-            locales_for(table).each do |locale|
-              Downloader.new(table.database).download_table(table, locale)
+          handle_safely do
+            tables.each do |table|
+              locales_for(table).each do |locale|
+                Downloader.new(table.database).download_table(table, locale)
+              end
             end
-          end
 
-          respond_with(200, {})
-        rescue => e
-          respond_with_error(500, "Internal server error: #{e.message}", e)
+            respond_with(200, {})
+          end
         end
 
         private

--- a/lib/txdb/handlers/triggers/pull_handler.rb
+++ b/lib/txdb/handlers/triggers/pull_handler.rb
@@ -1,0 +1,30 @@
+module Txdb
+  module Handlers
+    module Triggers
+
+      class PullHandler < Handler
+        def handle
+          tables.each do |table|
+            locales_for(table).each do |locale|
+              Downloader.new(table.database).download_table(table, locale)
+            end
+          end
+        end
+
+        private
+
+        def locales_for(table)
+          locale_cache[table.resource.project_slug] ||=
+            table.database.transifex_api.get_languages(
+              table.resource.project_slug
+            )
+        end
+
+        def locale_cache
+          @locale_cache ||= {}
+        end
+      end
+
+    end
+  end
+end

--- a/lib/txdb/handlers/triggers/pull_handler.rb
+++ b/lib/txdb/handlers/triggers/pull_handler.rb
@@ -9,15 +9,17 @@ module Txdb
               Downloader.new(table.database).download_table(table, locale)
             end
           end
+
+          respond_with(200, {})
         end
 
         private
 
         def locales_for(table)
           locale_cache[table.resource.project_slug] ||=
-            table.database.transifex_api.get_languages(
-              table.resource.project_slug
-            )
+            table.database.transifex_api
+              .get_languages(table.resource.project_slug)
+              .map { |locale| locale['language_code'] }
         end
 
         def locale_cache

--- a/lib/txdb/handlers/triggers/pull_handler.rb
+++ b/lib/txdb/handlers/triggers/pull_handler.rb
@@ -11,6 +11,8 @@ module Txdb
           end
 
           respond_with(200, {})
+        rescue => e
+          respond_with_error(500, "Internal server error: #{e.message}", e)
         end
 
         private

--- a/lib/txdb/handlers/triggers/push_handler.rb
+++ b/lib/txdb/handlers/triggers/push_handler.rb
@@ -9,6 +9,8 @@ module Txdb
           end
 
           respond_with(200, {})
+        rescue => e
+          respond_with_error(500, "Internal server error: #{e.message}", e)
         end
       end
 

--- a/lib/txdb/handlers/triggers/push_handler.rb
+++ b/lib/txdb/handlers/triggers/push_handler.rb
@@ -1,0 +1,15 @@
+module Txdb
+  module Handlers
+    module Triggers
+
+      class PushHandler < Handler
+        def handle
+          tables.each do |table|
+            Uploader.new(table.database).upload_table(table)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/txdb/handlers/triggers/push_handler.rb
+++ b/lib/txdb/handlers/triggers/push_handler.rb
@@ -4,13 +4,13 @@ module Txdb
 
       class PushHandler < Handler
         def handle
-          tables.each do |table|
-            Uploader.new(table.database).upload_table(table)
-          end
+          handle_safely do
+            tables.each do |table|
+              Uploader.new(table.database).upload_table(table)
+            end
 
-          respond_with(200, {})
-        rescue => e
-          respond_with_error(500, "Internal server error: #{e.message}", e)
+            respond_with(200, {})
+          end
         end
       end
 

--- a/lib/txdb/handlers/triggers/push_handler.rb
+++ b/lib/txdb/handlers/triggers/push_handler.rb
@@ -7,6 +7,8 @@ module Txdb
           tables.each do |table|
             Uploader.new(table.database).upload_table(table)
           end
+
+          respond_with(200, {})
         end
       end
 

--- a/lib/txdb/hooks.rb
+++ b/lib/txdb/hooks.rb
@@ -1,0 +1,7 @@
+require 'sinatra'
+require 'sinatra/json'
+
+class Hooks < Sinatra::Base
+  post '/transifex' do
+  end
+end

--- a/lib/txdb/hooks.rb
+++ b/lib/txdb/hooks.rb
@@ -1,7 +1,0 @@
-require 'sinatra'
-require 'sinatra/json'
-
-class Hooks < Sinatra::Base
-  post '/transifex' do
-  end
-end

--- a/lib/txdb/response.rb
+++ b/lib/txdb/response.rb
@@ -1,0 +1,11 @@
+module Txdb
+  class Response
+    attr_reader :status, :body, :error
+
+    def initialize(status, body, error = nil)
+      @status = status
+      @body = body
+      @error = error
+    end
+  end
+end

--- a/lib/txdb/response_helpers.rb
+++ b/lib/txdb/response_helpers.rb
@@ -1,0 +1,26 @@
+module Txdb
+  module ResponseHelpers
+    private
+
+    def respond_with(status, body, e = nil)
+      Txdb::Response.new(status, body, e)
+    end
+
+    def respond_with_error(status, message, e = nil)
+      respond_with(status, error(message), e)
+    end
+
+    def error(message)
+      [{ error: message }]
+    end
+
+    def data(body)
+      { data: body }
+    end
+
+    # includes these methods in the singleton class as well
+    def self.included(base)
+      base.extend(self)
+    end
+  end
+end

--- a/lib/txdb/transifex_project.rb
+++ b/lib/txdb/transifex_project.rb
@@ -3,13 +3,14 @@ require 'txgh'
 module Txdb
   class TransifexProject
     attr_reader :organization, :project_slug, :username, :password
-    attr_reader :api
+    attr_reader :webhook_secret, :api
 
     def initialize(options = {})
       @organization = options.fetch(:organization)
       @project_slug = options.fetch(:project_slug)
       @username = options.fetch(:username)
       @password = options.fetch(:password)
+      @webhook_secret = options.fetch(:webhook_secret)
       @api = Txgh::TransifexApi.create_from_credentials(username, password)
     end
   end

--- a/lib/txdb/tx_resource.rb
+++ b/lib/txdb/tx_resource.rb
@@ -23,7 +23,7 @@ module Txdb
       end
 
       def resource_slug(table)
-        Txgh::Utils.slugify(table.name)
+        Txgh::Utils.slugify("#{table.database.database}-#{table.name}")
       end
 
       def source_lang(table)

--- a/lib/txdb/uploader.rb
+++ b/lib/txdb/uploader.rb
@@ -18,13 +18,13 @@ module Txdb
       end
     end
 
-    private
-
     def upload_table(table)
       transifex_api.create_or_update(
         table.resource, table.read_content
       )
     end
+
+    private
 
     def transifex_api
       database.transifex_api

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -4,7 +4,13 @@ require 'tempfile'
 require 'yaml'
 
 describe Txdb::Config do
-  describe '#databases' do
+  before(:each) do
+    # clear out config before each test
+    Txdb::Config.instance_variable_set(:@databases, nil)
+    Txdb::Config.instance_variable_set(:@raw_config, nil)
+  end
+
+  describe '.databases' do
     it 'loads config from a string' do
       with_env('TXDB_CONFIG' => "raw://#{YAML.dump(TestDb.raw_config)}") do
         expect(Txdb::Config.databases.size).to eq(1)
@@ -34,6 +40,32 @@ describe Txdb::Config do
 
       file.close
       file.unlink
+    end
+  end
+
+  describe '.each_table' do
+    it 'returns an enumerator' do
+      expect(Txdb::Config.each_table).to be_a(Enumerator)
+    end
+
+    it 'yields each table in each database' do
+      # set up another database with another table so we can make sure the
+      # method loops over more than one db, yielding tables from each
+      config = TestDb.raw_config.dup
+      config[:databases] = config[:databases].dup
+      config[:databases] << config[:databases].first.merge(
+        database: 'spec/test2.sqlite3',
+        tables: [
+          name: 'another_table',
+          source_lang: 'en',
+          columns: %w(col1 col2)
+        ]
+      )
+
+      with_env('TXDB_CONFIG' => "raw://#{YAML.dump(config)}") do
+        result = Txdb::Config.each_table.to_a
+        expect(result.map(&:name)).to eq(%w(my_table another_table))
+      end
     end
   end
 end

--- a/spec/downloader_spec.rb
+++ b/spec/downloader_spec.rb
@@ -19,7 +19,7 @@ describe Downloader, test_db: true do
     it 'downloads translations from Transifex and writes them to the db' do
       expect(transifex_api).to receive(:download) do |resource, locale|
         expect(resource.project_slug).to eq('myproject')
-        expect(resource.resource_slug).to eq('my_table')
+        expect(resource.resource_slug).to eq('spec_test.sqlite3-my_table')
         expect(locale).to eq('es')
         YAML.dump('widgets')
       end

--- a/spec/handlers/hook_handler_spec.rb
+++ b/spec/handlers/hook_handler_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'spec_helpers/test_backend'
 require 'spec_helpers/test_db'
 require 'uri'
+require 'yaml'
 
 include Txdb::Handlers
 
@@ -46,7 +47,9 @@ describe HookHandler do
     it 'downloads and writes new content to the database' do
       expect(project.api).to receive(:download).and_return(YAML.dump(content))
 
-      post '/transifex', body, headers
+      expect { post('/transifex', body, headers) }.to(
+        change { Txdb::TestBackend.writes.size }.from(0).to(1)
+      )
 
       expect(last_response.status).to eq(200)
       expect(last_response.body).to eq('{}')

--- a/spec/handlers/hook_handler_spec.rb
+++ b/spec/handlers/hook_handler_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 require 'spec_helpers/test_backend'
 require 'spec_helpers/test_db'
-require 'spec_helpers/test_request'
 require 'uri'
 
 include Txdb::Handlers
@@ -27,20 +26,45 @@ describe HookHandler do
     )
   end
 
-  it 'downloads and writes new content to the database' do
-    content = { 'phrase' => 'trans' }
-    expect(project.api).to receive(:download).and_return(YAML.dump(content))
+  it "doesn't write content when unauthorized" do
     params = { 'resource' => table.resource.resource_slug, 'language' => 'es' }
     body = URI.encode_www_form(params.to_a)
-    headers = { Txgh::TransifexRequestAuth::RACK_HEADER => sign(body) }
-
-    post '/transifex', body, headers
+    post '/transifex', body
 
     expect(last_response.status).to eq(200)
     expect(last_response.body).to eq('{}')
 
-    expect(Txdb::TestBackend.writes).to include(
-      locale: 'es', table: table.name, content: content
-    )
+    expect(Txdb::TestBackend.writes).to be_empty
+  end
+
+  context 'with an authorized request' do
+    let(:content) { { 'phrase' => 'trans' } }
+    let(:params) { { 'resource' => table.resource.resource_slug, 'language' => 'es' } }
+    let(:body) { URI.encode_www_form(params.to_a) }
+    let(:headers) { { Txgh::TransifexRequestAuth::RACK_HEADER => sign(body) } }
+
+    it 'downloads and writes new content to the database' do
+      expect(project.api).to receive(:download).and_return(YAML.dump(content))
+
+      post '/transifex', body, headers
+
+      expect(last_response.status).to eq(200)
+      expect(last_response.body).to eq('{}')
+
+      expect(Txdb::TestBackend.writes).to include(
+        locale: 'es', table: table.name, content: content
+      )
+    end
+
+    it 'reports errors' do
+      expect(project.api).to receive(:download).and_raise('jelly beans')
+
+      post '/transifex', body, headers
+
+      expect(last_response.status).to eq(500)
+      expect(JSON.parse(last_response.body)).to eq(
+        [{ 'error' => 'Internal server error: jelly beans' }]
+      )
+    end
   end
 end

--- a/spec/handlers/hook_handler_spec.rb
+++ b/spec/handlers/hook_handler_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'spec_helpers/test_backend'
+require 'spec_helpers/test_db'
+require 'spec_helpers/test_request'
+require 'uri'
+
+include Txdb::Handlers
+
+describe HookHandler do
+  include Rack::Test::Methods
+
+  let(:database) { TestDb.database }
+  let(:table) { database.tables.first }
+  let(:project) { database.transifex_project }
+
+  def app
+    Txdb::Hooks
+  end
+
+  before(:each) do
+    allow(Txdb::Config).to receive(:databases).and_return([database])
+  end
+
+  def sign(body)
+    Txgh::TransifexRequestAuth.header_value(
+      body, project.webhook_secret
+    )
+  end
+
+  it 'downloads and writes new content to the database' do
+    content = { 'phrase' => 'trans' }
+    expect(project.api).to receive(:download).and_return(YAML.dump(content))
+    params = { 'resource' => table.resource.resource_slug, 'language' => 'es' }
+    body = URI.encode_www_form(params.to_a)
+    headers = { Txgh::TransifexRequestAuth::RACK_HEADER => sign(body) }
+
+    post '/transifex', body, headers
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('{}')
+
+    expect(Txdb::TestBackend.writes).to include(
+      locale: 'es', table: table.name, content: content
+    )
+  end
+end

--- a/spec/handlers/triggers/pull_handler_spec.rb
+++ b/spec/handlers/triggers/pull_handler_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'spec_helpers/test_backend'
+require 'spec_helpers/test_db'
+require 'uri'
+require 'yaml'
+
+include Txdb::Handlers::Triggers
+
+describe PullHandler do
+  include Rack::Test::Methods
+
+  let(:database) { TestDb.database }
+  let(:table) { database.tables.first }
+  let(:project) { database.transifex_project }
+
+  def app
+    Txdb::Triggers
+  end
+
+  before(:each) do
+    allow(Txdb::Config).to receive(:databases).and_return([database])
+  end
+
+  let(:params) do
+    { 'database' => database.database, 'table' => table.name }
+  end
+
+  it 'downloads the table for each locale' do
+    locales = [{ 'language_code' => 'es' }, { 'language_code' => 'ja' }]
+    content = { 'phrase' => 'trans' }
+    expect(database.transifex_api).to receive(:get_languages).and_return(locales)
+    allow(database.transifex_api).to receive(:download).and_return(YAML.dump(content))
+
+    expect { patch('/pull', params) }.to(
+      change { Txdb::TestBackend.writes.size }.from(0).to(2)
+    )
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('{}')
+
+    expect(Txdb::TestBackend.writes).to include(
+      locale: 'es', table: table.name, content: content
+    )
+
+    expect(Txdb::TestBackend.writes).to include(
+      locale: 'ja', table: table.name, content: content
+    )
+  end
+
+  it 'reports errors' do
+    expect(database.transifex_api).to receive(:get_languages).and_raise('jelly beans')
+    patch '/pull', params
+    expect(last_response.status).to eq(500)
+    expect(JSON.parse(last_response.body)).to eq(
+      [{ 'error' => 'Internal server error: jelly beans' }]
+    )
+  end
+end

--- a/spec/handlers/triggers/push_handler_spec.rb
+++ b/spec/handlers/triggers/push_handler_spec.rb
@@ -1,0 +1,49 @@
+require 'spec_helper'
+require 'spec_helpers/test_backend'
+require 'spec_helpers/test_db'
+require 'uri'
+require 'yaml'
+
+include Txdb::Handlers::Triggers
+
+describe PushHandler do
+  include Rack::Test::Methods
+
+  let(:database) { TestDb.database }
+  let(:table) { database.tables.first }
+  let(:project) { database.transifex_project }
+
+  def app
+    Txdb::Triggers
+  end
+
+  before(:each) do
+    allow(Txdb::Config).to receive(:databases).and_return([database])
+  end
+
+  let(:params) do
+    { 'database' => database.database, 'table' => table.name }
+  end
+
+  it 'uploads the table' do
+    expect(database.transifex_api).to receive(:create_or_update)
+
+    expect { patch('/push', params) }.to(
+      change { Txdb::TestBackend.reads.size }.from(0).to(1)
+    )
+
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq('{}')
+
+    expect(Txdb::TestBackend.reads).to include(table: table.name)
+  end
+
+  it 'reports errors' do
+    expect(database.transifex_api).to receive(:create_or_update).and_raise('jelly beans')
+    patch '/push', params
+    expect(last_response.status).to eq(500)
+    expect(JSON.parse(last_response.body)).to eq(
+      [{ 'error' => 'Internal server error: jelly beans' }]
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'pry-byebug'
+require 'rack/test'
 require 'rake'
 require 'rspec'
 require 'sequel'

--- a/spec/spec_helpers/test_db.rb
+++ b/spec/spec_helpers/test_db.rb
@@ -28,7 +28,8 @@ class TestDb
             organization: 'myorg',
             project_slug: 'myproject',
             username: 'username',
-            password: 'password'
+            password: 'password',
+            webhook_secret: '123abc'
           },
           tables: [{
             name: 'my_table',

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -20,7 +20,9 @@ describe Table, test_db: true do
       resource = table.resource
       expect(resource).to be_a(Txdb::TxResource)
       expect(resource.project_slug).to eq('myproject')
-      expect(resource.resource_slug).to eq(table.name)
+      expect(resource.resource_slug).to eq(
+        Txgh::Utils.slugify("#{database.database}-#{table.name}")
+      )
       expect(resource.source_file).to eq(table.name)
       expect(resource.source_lang).to eq('en')
     end

--- a/spec/tx_resource_spec.rb
+++ b/spec/tx_resource_spec.rb
@@ -10,6 +10,8 @@ describe TxResource, test_db: true do
 
   it 'proxies methods to the underlying Txgh::TxResource' do
     expect(resource.project_slug).to eq('myproject')
-    expect(resource.resource_slug).to eq(table.name)
+    expect(resource.resource_slug).to(
+      eq(Txgh::Utils.slugify("#{database.database}-#{table.name}"))
+    )
   end
 end

--- a/spec/uploader_spec.rb
+++ b/spec/uploader_spec.rb
@@ -19,7 +19,9 @@ describe Uploader, test_db: true do
     it 'reads phrases from the database and uploads them to Transifex' do
       expect(transifex_api).to receive(:create_or_update) do |resource, content|
         expect(resource.project_slug).to eq('myproject')
-        expect(resource.resource_slug).to eq('my_table')
+        expect(resource.resource_slug).to(
+          eq(Txgh::Utils.slugify("#{database.database}-#{database.tables.first.name}"))
+        )
       end
 
       expect { uploader.upload }.to(


### PR DESCRIPTION
Adds the following endpoints:
- `/hooks/transifex` - point Transifex webhooks at this endpoint
- `/triggers/push` - push database content up to Transifex
- `/triggers/pull` - pull database content down from Transifex and write it to the database

@lumoslabs/platform 
