### PR TITLE
Use English translation entries

### DIFF
--- a/lib/txdb/backends/globalize/helpers.rb
+++ b/lib/txdb/backends/globalize/helpers.rb
@@ -7,12 +7,22 @@ module Txdb
       module Helpers
         def origin_table_name(table_name)
           ActiveSupport::Inflector.pluralize(
-            table_name.sub(/_translations\z/, '')
-          )
+            origin_table_name_singular(table_name)
+          ).to_sym
+        end
+
+        def origin_column_name(table_name)
+          "#{origin_table_name_singular(table_name)}_id".to_sym
         end
 
         def resource_slug_for(table)
           Txgh::Utils.slugify("#{table.database.name}-#{table.name}")
+        end
+
+        private
+
+        def origin_table_name_singular(table_name)
+          table_name.sub(/_translations\z/, '')
         end
       end
 

--- a/lib/txdb/backends/globalize/reader.rb
+++ b/lib/txdb/backends/globalize/reader.rb
@@ -47,12 +47,12 @@ module Txdb
         end
 
         def content
-          @content ||= { origin_table_name(table.name) => content_for_records }
+          @content ||= { table.name => content_for_records }
         end
 
         def content_for_records
           iterator.each_with_object({}) do |record, ret|
-            ret[record[:id]] = content_for_record(record)
+            ret[record[origin_column]] = content_for_record(record)
           end
         end
 
@@ -64,6 +64,10 @@ module Txdb
               ret[col.to_s] = value
             end
           end
+        end
+
+        def origin_column
+          origin_column_name(table.name)
         end
 
         def iterator

--- a/lib/txdb/backends/globalize/writer.rb
+++ b/lib/txdb/backends/globalize/writer.rb
@@ -15,23 +15,23 @@ module Txdb
 
         def write_content(resource, locale)
           content = deserialize_content(resource.content)
-          content = content.fetch(origin_table_name(table.name), {})
+          content = content.fetch(table.name, {})
 
-          content.each_pair do |id, fields|
-            update_row(id, fields, locale)
+          content.each_pair do |foreign_id, fields|
+            update_row(foreign_id, fields, locale)
           end
         end
 
         private
 
-        def update_row(id, fields, locale)
+        def update_row(foreign_id, fields, locale)
           row = table.connection.where(
-            foreign_key.to_sym => id, locale: locale
+            origin_column => foreign_id, locale: locale
           )
 
           if row.empty?
             table.connection << fields
-              .merge(foreign_key.to_sym => id, locale: locale)
+              .merge(origin_column => foreign_id, locale: locale)
               .merge(created_at)
               .merge(updated_at)
           else
@@ -57,8 +57,8 @@ module Txdb
           YAML.load(content)
         end
 
-        def foreign_key
-          @foreign_key ||= table.name.sub(/_translations/, '_id')
+        def origin_column
+          origin_column_name(table.name)
         end
       end
 

--- a/lib/txdb/backends/globalize/writer.rb
+++ b/lib/txdb/backends/globalize/writer.rb
@@ -17,21 +17,21 @@ module Txdb
           content = deserialize_content(resource.content)
           content = content.fetch(table.name, {})
 
-          content.each_pair do |foreign_id, fields|
-            update_row(foreign_id, fields, locale)
+          content.each_pair do |parent_id, fields|
+            update_row(parent_id, fields, locale)
           end
         end
 
         private
 
-        def update_row(foreign_id, fields, locale)
+        def update_row(parent_id, fields, locale)
           row = table.connection.where(
-            origin_column => foreign_id, locale: locale
+            origin_column => parent_id, locale: locale
           )
 
           if row.empty?
             table.connection << fields
-              .merge(origin_column => foreign_id, locale: locale)
+              .merge(origin_column => parent_id, locale: locale)
               .merge(created_at)
               .merge(updated_at)
           else

--- a/lib/txdb/iterators/auto_increment_iterator.rb
+++ b/lib/txdb/iterators/auto_increment_iterator.rb
@@ -29,7 +29,7 @@ module Txdb
             last_value = record[column]
           end
 
-          counter = last_value + 1
+          counter = last_value + 1 if last_value
         end
       end
 
@@ -48,12 +48,13 @@ module Txdb
       private
 
       def records_since(counter)
-        sql_column = Sequel.expr(column)
+        sql_column = Sequel.qualify(table_name, column)
 
         table.connection
+          .select_all(table_name)
           .from(table_name)
           .where { sql_column >= counter }
-          .order(column)
+          .order(sql_column)
           .limit(batch_size)
       end
 

--- a/lib/txdb/iterators/globalize_iterator.rb
+++ b/lib/txdb/iterators/globalize_iterator.rb
@@ -5,8 +5,22 @@ module Txdb
 
       include Backends::Globalize::Helpers
 
-      def table_name
-        origin_table_name(table.name)
+      def records_since(counter)
+        super
+          .join(origin_table, column => origin_column)
+          .where(locale_column => table.source_lang)
+      end
+
+      def locale_column
+        Sequel.qualify(table_name, :locale)
+      end
+
+      def origin_column
+        Sequel.qualify(table_name, origin_column_name(table_name))
+      end
+
+      def origin_table
+        Sequel.expr(origin_table_name(table_name))
       end
     end
   end

--- a/spec/backends/globalize/helpers_spec.rb
+++ b/spec/backends/globalize/helpers_spec.rb
@@ -7,12 +7,12 @@ describe Globalize::Helpers, test_config: true do
   describe '.origin_table_name' do
     it 'pluralizes and removes the translations suffix' do
       origin = Globalize::Helpers.origin_table_name('widget_translations')
-      expect(origin).to eq('widgets')
+      expect(origin).to eq(:widgets)
     end
 
     it 'handles unusual pluralizations (via ActiveSupport::Inflector)' do
       origin = Globalize::Helpers.origin_table_name('ox_translations')
-      expect(origin).to eq('oxen')
+      expect(origin).to eq(:oxen)
     end
   end
 

--- a/spec/backends/globalize/reader_spec.rb
+++ b/spec/backends/globalize/reader_spec.rb
@@ -11,6 +11,9 @@ describe Globalize::Reader, globalize_config: true do
     it 'reads data from the given table and returns an array of resources' do
       sprocket_id = widgets.connection.insert(name: 'sprocket')
       flange_id = widgets.connection.insert(name: 'flange')
+
+      widget_translations.connection.insert(widget_id: sprocket_id, locale: 'en', name: 'sprocket')
+      widget_translations.connection.insert(widget_id: flange_id, locale: 'en', name: 'flange')
       widget_translations.connection.insert(widget_id: sprocket_id, locale: 'es', name: 'sproqueta')
       widget_translations.connection.insert(widget_id: flange_id, locale: 'es', name: 'flango')
 
@@ -27,9 +30,9 @@ describe Globalize::Reader, globalize_config: true do
 
       expect(resource.content).to eq(
         YAML.dump(
-          'widgets' => {
-            1 => { 'name' => 'sprocket' },
-            2 => { 'name' => 'flange' }
+          'widget_translations' => {
+            sprocket_id => { 'name' => 'sprocket' },
+            flange_id => { 'name' => 'flange' }
           }
         )
       )

--- a/spec/iterators/globalize_iterator_spec.rb
+++ b/spec/iterators/globalize_iterator_spec.rb
@@ -13,6 +13,7 @@ describe GlobalizeIterator, test_config: true do
 
       create_table(:team_translations) do
         primary_key :id
+        integer :team_id
         string :name, translate: true
         string :locale
         source_lang 'en'
@@ -30,8 +31,10 @@ describe GlobalizeIterator, test_config: true do
 
   it 'iterates over the items in the parent table' do
     teams.each do |team|
-      teams_table.connection << { name: team }
-      team_translations_table.connection << { name: "#{team}-es", locale: 'es' }
+      team_id = teams_table.connection.insert(name: team)
+      team_translations_table.connection.insert(
+        name: team, team_id: team_id, locale: 'en'
+      )
     end
 
     entries = iterator.map { |entry| entry[:name] }


### PR DESCRIPTION
Globalize automatically creates a translations table for any ActiveRecord model it's included in. For a table named `games`, for example, Globalize will create `game_translations`. In newer versions of Globalize, any columns declared as translatable are not saved in the model, but are instead saved as associated translations. For example, if our `games` table has a column called `name`, Globalize will not write `games.name` - it will create a new `game_translations` record with the locale set to the default locale ("en" in our case) and set `games.name` to `NULL`.

Originally, txdb used the values present in the parent table (i.e. `games`). This change uses the table's `source_lang` property to pull source strings from the associated translations table (i.e. `games_translations`) instead.
