### PR TITLE
Locales should be taken from config

### DIFF
--- a/lib/txdb/backends/globalize/reader.rb
+++ b/lib/txdb/backends/globalize/reader.rb
@@ -22,7 +22,7 @@ module Txdb
         def resource
           @resource ||= Txgh::TxResource.new(
             project_slug, resource_slug, Globalize::Backend::RESOURCE_TYPE,
-            source_lang, source_file, nil, nil
+            source_locale, source_file, nil, nil
           )
         end
 
@@ -34,8 +34,8 @@ module Txdb
           resource_slug_for(table)
         end
 
-        def source_lang
-          table.source_lang
+        def source_locale
+          table.database.source_locale
         end
 
         def source_file

--- a/lib/txdb/database.rb
+++ b/lib/txdb/database.rb
@@ -8,6 +8,7 @@ module Txdb
 
     attr_reader :adapter, :backend, :username, :password, :host, :port, :name
     attr_reader :pool, :transifex_project, :tables, :connection_string
+    attr_reader :locales, :source_locale
 
     def initialize(options = {})
       @adapter = options.fetch(:adapter)
@@ -18,6 +19,8 @@ module Txdb
       @port = options.fetch(:port, DEFAULT_PORT)
       @name = options.fetch(:name)
       @pool = options.fetch(:pool, DEFAULT_POOL)
+      @locales = options.fetch(:locales)
+      @source_locale = options.fetch(:source_locale)
       @transifex_project = TransifexProject.new(options.fetch(:transifex))
       @connection_string = ConnectionString.new(options).string
       @tables = options.fetch(:tables).map do |table_config|

--- a/lib/txdb/downloader.rb
+++ b/lib/txdb/downloader.rb
@@ -20,8 +20,8 @@ module Txdb
 
     def download_all
       database.tables.each do |table|
-        locales.each do |locale|
-          next if locale == table.source_lang
+        database.locales.each do |locale|
+          next if locale == database.source_locale
           download_table(table, locale)
         end
       end
@@ -66,12 +66,6 @@ module Txdb
         .map do |resource_hash|
           Txgh::TxResource.from_api_response(project_slug, resource_hash)
         end
-    end
-
-    def locales
-      @locales ||= database.transifex_api
-        .get_languages(database.transifex_project.project_slug)
-        .map { |locale| locale['language_code'] }
     end
   end
 end

--- a/lib/txdb/handlers/triggers/pull_handler.rb
+++ b/lib/txdb/handlers/triggers/pull_handler.rb
@@ -5,7 +5,7 @@ module Txdb
       class PullHandler < Handler
         def handle
           handle_safely do
-            locales.each do |locale|
+            database.locales.each do |locale|
               downloader.download_table(table, locale)
             end
 
@@ -17,12 +17,6 @@ module Txdb
 
         def downloader
           @downloader ||= Downloader.new(database)
-        end
-
-        def locales
-          database.transifex_api
-            .get_languages(database.transifex_project.project_slug)
-            .map { |locale| locale['language_code'] }
         end
       end
 

--- a/lib/txdb/iterators/globalize_iterator.rb
+++ b/lib/txdb/iterators/globalize_iterator.rb
@@ -8,7 +8,7 @@ module Txdb
       def records_since(counter)
         super
           .join(origin_table, column => origin_column)
-          .where(locale_column => table.source_lang)
+          .where(locale_column => table.database.source_locale)
       end
 
       def locale_column

--- a/lib/txdb/table.rb
+++ b/lib/txdb/table.rb
@@ -3,13 +3,11 @@ require 'txgh'
 module Txdb
   class Table
     attr_reader :database, :name, :columns
-    attr_reader :source_lang
 
     def initialize(database, options = {})
       @database = database
       @name = options.fetch(:name)
       @columns = options.fetch(:columns)
-      @source_lang = options.fetch(:source_lang)
     end
 
     def connection

--- a/spec/backends/globalize/writer_spec.rb
+++ b/spec/backends/globalize/writer_spec.rb
@@ -11,11 +11,11 @@ describe Globalize::Writer, globalize_config: true do
 
   describe '#write_content' do
     let(:base_resource) do
-      # project_slug, resource_slug, type, source_lang, source_file,
+      # project_slug, resource_slug, type, source_locale, source_file,
       # lang_map, translation_file
       Txgh::TxResource.new(
         'project_slug', 'resource_slug', Globalize::Backend::RESOURCE_TYPE,
-        'source_lang', 'source_file', nil, nil
+        'source_locale', 'source_file', nil, nil
       )
     end
 

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -16,7 +16,6 @@ describe Txdb::Config do
         Txdb::TestConfigurator.base_config.tap do |base_config|
           base_config[:tables] << {
             name: 'my_table',
-            source_lang: 'en',
             columns: []
           }
         end
@@ -69,9 +68,9 @@ describe Txdb::Config do
       # method loops over more than one db, yielding tables from each
       config[:databases] << config[:databases].first.merge(
         database: 'spec/test2.sqlite3',
+        source_locale: 'en',
         tables: [
           name: 'another_table',
-          source_lang: 'en',
           columns: %w(col1 col2)
         ]
       )

--- a/spec/handlers/triggers/pull_handler_spec.rb
+++ b/spec/handlers/triggers/pull_handler_spec.rb
@@ -33,17 +33,15 @@ describe PullHandler, test_config: true do
   end
 
   it 'downloads the table for each locale' do
-    locales = [{ 'language_code' => 'es' }, { 'language_code' => 'ja' }]
     content = { 'phrase' => 'trans' }
 
-    expect(database.transifex_api).to receive(:get_languages).and_return(locales)
     allow(database.transifex_api).to receive(:download).and_return(YAML.dump(content))
     expect(database.transifex_api).to receive(:get_resources).and_return(
       [Txdb::TestBackend.resource.to_api_h]
     )
 
     expect { patch('/pull', params) }.to(
-      change { Txdb::TestBackend.writes.size }.from(0).to(2)
+      change { Txdb::TestBackend.writes.size }.from(0).to(2)  # ja and es
     )
 
     expect(last_response.status).to eq(200)
@@ -66,7 +64,7 @@ describe PullHandler, test_config: true do
   end
 
   it 'reports errors' do
-    expect(database.transifex_api).to receive(:get_languages).and_raise('jelly beans')
+    expect(database).to receive(:locales).and_raise('jelly beans')
     patch '/pull', params
     expect(last_response.status).to eq(500)
     expect(JSON.parse(last_response.body)).to eq(

--- a/spec/iterators/auto_increment_iterator_spec.rb
+++ b/spec/iterators/auto_increment_iterator_spec.rb
@@ -9,7 +9,6 @@ describe AutoIncrementIterator, test_config: true do
       create_table(:teams) do
         primary_key :id
         string :name, translate: true
-        source_lang 'en'
       end
     end
   end

--- a/spec/iterators/globalize_iterator_spec.rb
+++ b/spec/iterators/globalize_iterator_spec.rb
@@ -16,7 +16,6 @@ describe GlobalizeIterator, test_config: true do
         integer :team_id
         string :name, translate: true
         string :locale
-        source_lang 'en'
       end
     end
   end

--- a/spec/spec_helpers/globalize_configurator.rb
+++ b/spec/spec_helpers/globalize_configurator.rb
@@ -17,7 +17,6 @@ module Txdb
             integer :widget_id
             string :locale
             string :name, translate: true
-            source_lang 'en'
           end
 
           block.call if block

--- a/spec/spec_helpers/test_backend.rb
+++ b/spec/spec_helpers/test_backend.rb
@@ -31,7 +31,7 @@ module Txdb
       def base_resource
         @base_resource ||= Txgh::TxResource.new(
           'myproject', 'resource_slug', 'type',
-          'source_lang', 'source_file', nil, nil
+          'source_locale', 'source_file', nil, nil
         )
       end
 

--- a/spec/spec_helpers/test_configurator.rb
+++ b/spec/spec_helpers/test_configurator.rb
@@ -63,6 +63,8 @@ module Txdb
           username: 'username',
           password: 'password',
           name: 'spec/test.sqlite3',
+          locales: %w(es ja),
+          source_locale: 'en',
           transifex: {
             organization: 'myorg',
             project_slug: 'myproject',
@@ -95,7 +97,7 @@ module Txdb
   end
 
   class TableCreator
-    attr_reader :name, :database, :columns, :source_lang
+    attr_reader :name, :database, :columns
 
     def initialize(name, database, &block)
       @name = name
@@ -117,14 +119,10 @@ module Txdb
       add_column(column, :integer, *args)
     end
 
-    def source_lang(lang)
-      @source_lang = lang
-    end
-
     def table
       Txdb::Table.new(
         database, {
-          name: name.to_s, columns: columns, source_lang: @source_lang
+          name: name.to_s, columns: columns
         }
       )
     end


### PR DESCRIPTION
[PLAT-1228](https://lumoslabs.atlassian.net/browse/PLAT-1228)

Unfortunately Transifex returns the wrong set of locales for the given project slug. It seems to be returning locales assigned to all the contributors and maintainers, which includes en-US as well as en. Very confusing.

@lumoslabs/platform 
